### PR TITLE
feat(header-auth-button): ajusta ícones e adiciona testes do componente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,4 @@
 # 4. O arquivo '.env' está incluído no .gitignore e NUNCA deve ser commitado.
 # ==============================================================================
 
-
+PUBLIC_API_URL=http://localhost:5000/

--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,4 @@
 # 4. O arquivo '.env' está incluído no .gitignore e NUNCA deve ser commitado.
 # ==============================================================================
 
-PUBLIC_API_URL=http://localhost:5000
+

--- a/src/components/ui/button/button.spec.tsx
+++ b/src/components/ui/button/button.spec.tsx
@@ -1,9 +1,11 @@
-import { describe, expect, it, mock } from "bun:test";
-import { render, screen } from "@testing-library/react";
+import { describe, expect, it, mock, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
 
 import { Button } from ".";
 
 describe("Button component", () => {
+  afterEach(cleanup);
+
   it("should render the button", () => {
     render(<Button>Click me</Button>);
     expect(screen.getByRole("button")).toHaveTextContent("Click me");

--- a/src/components/ui/header-auth-button/HeaderAuthButton.spec.tsx
+++ b/src/components/ui/header-auth-button/HeaderAuthButton.spec.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, mock, afterEach } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { HeaderAuthButton } from ".";
+
+describe("HeaderAuthButton component", () => {
+  afterEach(cleanup);
+
+  it("should render 'Entrar/Cadastrar' by default", () => {
+    render(<HeaderAuthButton />);
+    expect(
+      screen.getByRole("button", { name: "Entrar/Cadastrar" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render 'Sair' when isLogged is true", () => {
+    render(<HeaderAuthButton isLogged />);
+    expect(screen.getByRole("button", { name: "Sair" })).toBeInTheDocument();
+  });
+
+  it("should trigger the action when clicked", () => {
+    const handleAction = mock();
+
+    render(<HeaderAuthButton action={handleAction} />);
+    screen.getByRole("button").click();
+
+    expect(handleAction).toHaveBeenCalled();
+  });
+
+  it("should not trigger the action if disabled", () => {
+    const handleAction = mock();
+
+    render(<HeaderAuthButton disabled action={handleAction} />);
+    screen.getByRole("button").click();
+
+    expect(handleAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/header-auth-button/index.tsx
+++ b/src/components/ui/header-auth-button/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { LogOutIcon } from "lucide-react";
 
 type HeaderAuthButtonProps = {
   isLogged?: boolean;
@@ -8,50 +9,13 @@ type HeaderAuthButtonProps = {
   type?: "button" | "submit" | "reset";
 };
 
-type ExitArrowIconProps = {
-  className?: string;
-};
-
-function ExitArrowIcon({ className = "" }: ExitArrowIconProps) {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 64 64"
-      fill="none"
-      className={className}
-    >
-      <path
-        d="M18 8H9a3 3 0 0 0-3 3v42a3 3 0 0 0 3 3h9"
-        stroke="currentColor"
-        strokeWidth="4.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M22 32h29"
-        stroke="currentColor"
-        strokeWidth="4.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M38 16l16 16-16 16"
-        stroke="currentColor"
-        strokeWidth="4.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
 export function HeaderAuthButton({
   isLogged = false,
   action,
   disabled = false,
   className = "",
   type = "button",
-}: HeaderAuthButtonProps) {
+}: Readonly<HeaderAuthButtonProps>) {
   const label = isLogged ? "Sair" : "Entrar/Cadastrar";
 
   return (
@@ -66,6 +30,7 @@ export function HeaderAuthButton({
       className={[
         "inline-flex items-center gap-2",
         "rounded-none",
+        "bg-dark-blue text-white",
         "font-['Roboto'] font-bold",
         "hover:opacity-90",
         "active:opacity-80",
@@ -73,9 +38,9 @@ export function HeaderAuthButton({
         className,
       ].join(" ")}
     >
-      {!isLogged && <ExitArrowIcon className="h-4 w-4 shrink-0" />}
+      {!isLogged && <LogOutIcon className="h-4 w-4 shrink-0" />}
       <span>{label}</span>
-      {isLogged && <ExitArrowIcon className="h-4 w-4 shrink-0" />}
+      {isLogged && <LogOutIcon className="h-4 w-4 shrink-0" />}
     </Button>
   );
 }

--- a/src/components/ui/header-auth-button/index.tsx
+++ b/src/components/ui/header-auth-button/index.tsx
@@ -1,0 +1,81 @@
+import { Button } from "@/components/ui/button";
+
+type HeaderAuthButtonProps = {
+  isLogged?: boolean;
+  action?: () => void;
+  disabled?: boolean;
+  className?: string;
+  type?: "button" | "submit" | "reset";
+};
+
+type ExitArrowIconProps = {
+  className?: string;
+};
+
+function ExitArrowIcon({ className = "" }: ExitArrowIconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 64 64"
+      fill="none"
+      className={className}
+    >
+      <path
+        d="M18 8H9a3 3 0 0 0-3 3v42a3 3 0 0 0 3 3h9"
+        stroke="currentColor"
+        strokeWidth="4.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M22 32h29"
+        stroke="currentColor"
+        strokeWidth="4.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M38 16l16 16-16 16"
+        stroke="currentColor"
+        strokeWidth="4.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function HeaderAuthButton({
+  isLogged = false,
+  action,
+  disabled = false,
+  className = "",
+  type = "button",
+}: HeaderAuthButtonProps) {
+  const label = isLogged ? "Sair" : "Entrar/Cadastrar";
+
+  return (
+    <Button
+      type={type}
+      onClick={action}
+      disabled={disabled}
+      size="md"
+      icon={isLogged ? "right" : "left"}
+      aria-label={label}
+      data-testid="header-auth-button"
+      className={[
+        "inline-flex items-center gap-2",
+        "rounded-none",
+        "font-['Roboto'] font-bold",
+        "hover:opacity-90",
+        "active:opacity-80",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30",
+        className,
+      ].join(" ")}
+    >
+      {!isLogged && <ExitArrowIcon className="h-4 w-4 shrink-0" />}
+      <span>{label}</span>
+      {isLogged && <ExitArrowIcon className="h-4 w-4 shrink-0" />}
+    </Button>
+  );
+}

--- a/src/components/ui/header-auth-button/index.tsx
+++ b/src/components/ui/header-auth-button/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { cn } from "@/utils/cn";
 import { LogOutIcon } from "lucide-react";
 
 type HeaderAuthButtonProps = {
@@ -27,7 +28,7 @@ export function HeaderAuthButton({
       icon={isLogged ? "right" : "left"}
       aria-label={label}
       data-testid="header-auth-button"
-      className={[
+      className={cn(
         "inline-flex items-center gap-2",
         "rounded-none",
         "bg-dark-blue text-white",
@@ -36,7 +37,7 @@ export function HeaderAuthButton({
         "active:opacity-80",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30",
         className,
-      ].join(" ")}
+      )}
     >
       {!isLogged && <LogOutIcon className="h-4 w-4 shrink-0" />}
       <span>{label}</span>


### PR DESCRIPTION
## Alterações 
- adicionados testes do componente `HeaderAuthButton`
- criada a spec do componente para validar renderização e comportamento
- ajustados os ícones do componente para uso com `Lucide`
- realizados ajustes no componente para compatibilidade com os testes
- atualizada a organização dos arquivos de teste relacionados ao componente
## Evidências

### Funcionais

<img width="293" height="69" alt="Captura de Tela 2026-04-08 às 18 18 17" src="https://github.com/user-attachments/assets/bd930b94-f1da-4e76-8b54-6f1f880372fd" />

### Não Funcionais

<img width="644" height="283" alt="Captura de Tela 2026-04-08 às 18 55 33" src="https://github.com/user-attachments/assets/4b6d89d0-de46-4ac3-b5d7-266320a6df61" />
