### PR TITLE
feat(sidebar-button): adiciona botões e ícones da sidebar

### DIFF
--- a/src/components/ui/sidebar/sidebarButton/buttonSidebar.tsx
+++ b/src/components/ui/sidebar/sidebarButton/buttonSidebar.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import {
+  LayoutDashboard,
+  Car,
+  Users,
+  Radio,
+  CreditCard,
+  Settings,
+} from "lucide-react";
+
+type menuItem = {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+};
+
+const menuItens: menuItem[] = [
+  { id: "dashboard", label: "DASHBOARD0", icon: <LayoutDashboard /> },
+  { id: "veiculos", label: "VEÍCULOS", icon: <Car /> },
+  { id: "usuarios", label: "USUÁRIOS", icon: <Users /> },
+  { id: "tag", label: "TAG", icon: <Radio /> },
+  { id: "cobranca", label: "COBRANÇA", icon: <CreditCard /> },
+  { id: "sistema", label: "SISTEMA", icon: <Settings /> },
+];
+
+export const buttonSidebar: React.FC = () => {
+  const [active, setActive] = useState("dashboard");
+  const [hovered, setHovered] = useState<string | null>(null);
+
+  return (
+    <div className="flex w-64 flex-col gap-2 bg-[#234A6B] p-4">
+      {menuItens.map((item) => {
+        const isActive = active === item.id;
+        const isHovered = hovered === item.id;
+
+        return (
+          <button
+            type="button"
+            key={item.id}
+            onClick={() => setActive(item.id)}
+            onMouseEnter={() => setHovered(item.id)}
+            onMouseLeave={() => setHovered(null)}
+            className={`flex w-full items-center gap-4 rounded-xl px-4 py-3 font-medium text-sm transition-all duration-200 ${
+              isActive
+                ? "bg-[#5A7696] text-white"
+                : isHovered
+                  ? "bg-[#2A4D6E] text-white"
+                  : "text-gray-200"
+            }
+                        `}
+          >
+            {/* Ícone */}
+            <span
+              className={`flex w-6 items-center justify-center text-xl transition-all duration-200 ${isHovered || isActive ? "scale-110" : ""}
+              `}
+            >
+              {item.icon}
+            </span>
+
+            {/* Texto */}
+            <span>{item.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};


### PR DESCRIPTION
- Contem os botões de Dashboard, Veículos, Usuários, Tag, Cobranças e de Sistema;
- Botões acompanhados de hover;
- Botões acompanhados de ícones similares aos do Figma com o Lucide;

<img width="877" height="454" alt="Captura de tela 2026-04-09 123429" src="https://github.com/user-attachments/assets/387728d8-374d-4a98-8a1e-f351269477ba" />


