### PR TITLE
feat: componentes dashboard

### DIFF
--- a/src/features/dashboard/components/dashboardCard.tsx
+++ b/src/features/dashboard/components/dashboardCard.tsx
@@ -28,11 +28,6 @@ export function MetricCard({
   size,
   className,
 }: MetricCardProps) {
-  if (!topLabel || !bottomLabel) {
-    throw new Error(
-      "topLabel e bottomLabel são obrigatórios e não podem ser vazios ",
-    );
-  }
   return (
     <div className={metricCard({ size, className })}>
       <span className="font-medium text-gray-500 text-sm">{topLabel}</span>

--- a/src/features/dashboard/components/dashboardCard.tsx
+++ b/src/features/dashboard/components/dashboardCard.tsx
@@ -2,35 +2,41 @@ import { cva } from "class-variance-authority";
 import type { VariantProps } from "class-variance-authority";
 
 const metricCard = cva(
-    "bg-white rounded-md drop-shadow-lg p-6 flex flex-col gap-2",
-    { 
-        variants: {
-           size: {
-              sm: "p-4",
-              md: "p-6",
-              lg: "p-8",
-         },
-     },
-     defaultVariants: {
-        size: "md",
-     },
-}
-)
+  "bg-white rounded-md drop-shadow-lg p-6 flex flex-col gap-2",
+  {
+    variants: {
+      size: {
+        sm: "p-4",
+        md: "p-6",
+        lg: "p-8",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  },
+);
 interface MetricCardProps extends VariantProps<typeof metricCard> {
-    topLabel: string;
-    bottomLabel: string;
-    className?: string;
-    
+  topLabel: string;
+  bottomLabel: string;
+  className?: string;
 }
 
-export function MetricCard({ topLabel, bottomLabel, size, className}: MetricCardProps) {
-    if (!topLabel || !bottomLabel){
-        throw new Error("topLabel e bottomLabel são obrigatórios e não podem ser vazios ")
-    }
-    return (
-        <div className={metricCard({size, className })}>
-            <span className="text-sm text-gray-500 font-medium">{topLabel}</span>
-            <span className="text-4xl font-bold text-gray-900">{bottomLabel} </span>
-        </div>
-    )
+export function MetricCard({
+  topLabel,
+  bottomLabel,
+  size,
+  className,
+}: MetricCardProps) {
+  if (!topLabel || !bottomLabel) {
+    throw new Error(
+      "topLabel e bottomLabel são obrigatórios e não podem ser vazios ",
+    );
+  }
+  return (
+    <div className={metricCard({ size, className })}>
+      <span className="font-medium text-gray-500 text-sm">{topLabel}</span>
+      <span className="font-bold text-4xl text-gray-900">{bottomLabel} </span>
+    </div>
+  );
 }

--- a/src/features/dashboard/components/dashboardCard.tsx
+++ b/src/features/dashboard/components/dashboardCard.tsx
@@ -1,0 +1,36 @@
+import { cva } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
+
+const metricCard = cva(
+    "bg-white rounded-md drop-shadow-lg p-6 flex flex-col gap-2",
+    { 
+        variants: {
+           size: {
+              sm: "p-4",
+              md: "p-6",
+              lg: "p-8",
+         },
+     },
+     defaultVariants: {
+        size: "md",
+     },
+}
+)
+interface MetricCardProps extends VariantProps<typeof metricCard> {
+    topLabel: string;
+    bottomLabel: string;
+    className?: string;
+    
+}
+
+export function MetricCard({ topLabel, bottomLabel, size, className}: MetricCardProps) {
+    if (!topLabel || !bottomLabel){
+        throw new Error("topLabel e bottomLabel são obrigatórios e não podem ser vazios ")
+    }
+    return (
+        <div className={metricCard({size, className })}>
+            <span className="text-sm text-gray-500 font-medium">{topLabel}</span>
+            <span className="text-4xl font-bold text-gray-900">{bottomLabel} </span>
+        </div>
+    )
+}

--- a/src/features/dashboard/components/dashboardCard.tsx
+++ b/src/features/dashboard/components/dashboardCard.tsx
@@ -1,5 +1,5 @@
-import { cva } from "class-variance-authority";
 import type { VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
 
 const metricCard = cva(
   "bg-white rounded-md drop-shadow-lg p-6 flex flex-col gap-2",
@@ -30,8 +30,8 @@ export function MetricCard({
 }: MetricCardProps) {
   return (
     <div className={metricCard({ size, className })}>
-      <span className="font-medium text-gray-500 text-sm">{topLabel}</span>
-      <span className="font-bold text-4xl text-gray-900">{bottomLabel} </span>
+      <span className="font-medium text-gray text-sm">{topLabel}</span>
+      <span className="font-bold text-4xl text-dark-gray">{bottomLabel} </span>
     </div>
   );
 }


### PR DESCRIPTION
Componentes de entrada, saída e horários com mais entrada criados. 
<img width="784" height="131" alt="Captura de Tela 2026-04-16 às 17 43 48" src="https://github.com/user-attachments/assets/3b453333-903e-4c25-b0fe-2051688ea551" />
