### PR TITLE
feat(tag-status-component): adiciona componente de status das etiquetas

### DIFF
--- a/src/features/dashboard/components/Status.tsx
+++ b/src/features/dashboard/components/Status.tsx
@@ -1,0 +1,44 @@
+
+import React from 'react';
+
+type Status = "ativa" | "livre" | "inativa";
+
+type StatusProps = {
+    status: Status;
+}
+
+const statusConfig: Record<Status, {label: string, className: string, dot: string}> = {
+    ativa: {
+        label: "Ativa",
+        className: "bg-light-green text-dark-gray",
+        dot: "bg-green",
+    },
+    livre: {
+        label: "Livre",
+        className: "bg-yellow text-dark-gray",
+        dot: "bg-dark-orange",
+    },
+    inativa: {
+        label: "Inativa",
+        className: "bg-light-red text-dark-gray",
+        dot: "bg-red",
+    },
+}
+
+export function StatusBadge({status}: StatusProps){
+    const config = statusConfig[status];
+
+    return(
+        <div
+           className={`flex flex-shrink-0 items-center gap-2 px-3 py-1 rounded-full text-sm font-medium ${config.className}`}
+        >
+            <span
+             className={`w-2 h-2 rounded-full ${config.dot}`}
+            />
+            <span>
+                {config.label}
+            </span>
+        </div>
+
+    );
+}

--- a/src/features/dashboard/components/Status.tsx
+++ b/src/features/dashboard/components/Status.tsx
@@ -1,5 +1,4 @@
 
-import React from 'react';
 
 type Status = "ativa" | "livre" | "inativa";
 
@@ -33,7 +32,7 @@ export function StatusBadge({status}: StatusProps){
            className={`flex flex-shrink-0 items-center gap-2 px-3 py-1 rounded-full text-sm font-medium ${config.className}`}
         >
             <span
-             className={`w-2 h-2 rounded-full ${config.dot}`}
+             className={`w-3 h-3 rounded-full ${config.dot}`}
             />
             <span>
                 {config.label}

--- a/src/features/dashboard/components/Status.tsx
+++ b/src/features/dashboard/components/Status.tsx
@@ -1,43 +1,39 @@
-
-
 type Status = "ativa" | "livre" | "inativa";
 
 type StatusProps = {
-    status: Status;
-}
+  status: Status;
+};
 
-const statusConfig: Record<Status, {label: string, className: string, dot: string}> = {
-    ativa: {
-        label: "Ativa",
-        className: "bg-light-green text-dark-gray",
-        dot: "bg-green",
-    },
-    livre: {
-        label: "Livre",
-        className: "bg-yellow text-dark-gray",
-        dot: "bg-dark-orange",
-    },
-    inativa: {
-        label: "Inativa",
-        className: "bg-light-red text-dark-gray",
-        dot: "bg-red",
-    },
-}
+const statusConfig: Record<
+  Status,
+  { label: string; className: string; dot: string }
+> = {
+  ativa: {
+    label: "Ativa",
+    className: "bg-light-green text-dark-gray",
+    dot: "bg-green",
+  },
+  livre: {
+    label: "Livre",
+    className: "bg-yellow text-dark-gray",
+    dot: "bg-dark-orange",
+  },
+  inativa: {
+    label: "Inativa",
+    className: "bg-light-red text-dark-gray",
+    dot: "bg-red",
+  },
+};
 
-export function StatusBadge({status}: StatusProps){
-    const config = statusConfig[status];
+export function StatusBadge({ status }: StatusProps) {
+  const config = statusConfig[status];
 
-    return(
-        <div
-           className={`flex flex-shrink-0 items-center gap-2 px-3 py-1 rounded-full text-sm font-medium ${config.className}`}
-        >
-            <span
-             className={`w-3 h-3 rounded-full ${config.dot}`}
-            />
-            <span>
-                {config.label}
-            </span>
-        </div>
-
-    );
+  return (
+    <div
+      className={`flex w-24 flex-shrink-0 items-center justify-center gap-2 rounded-full px-3 py-1 font-medium text-sm ${config.className}`}
+    >
+      <span className={`h-3 w-3 rounded-full ${config.dot}`} />
+      <span>{config.label}</span>
+    </div>
+  );
 }

--- a/src/features/dashboard/components/Status.tsx
+++ b/src/features/dashboard/components/Status.tsx
@@ -1,4 +1,6 @@
-type Status = "ativa" | "livre" | "inativa";
+import { cn } from "@/utils/cn";
+
+type Status = "active" | "available" | "inactive";
 
 type StatusProps = {
   status: Status;
@@ -8,17 +10,17 @@ const statusConfig: Record<
   Status,
   { label: string; className: string; dot: string }
 > = {
-  ativa: {
+  active: {
     label: "Ativa",
     className: "bg-light-green text-dark-gray",
     dot: "bg-green",
   },
-  livre: {
+  available: {
     label: "Livre",
     className: "bg-yellow text-dark-gray",
     dot: "bg-dark-orange",
   },
-  inativa: {
+  inactive: {
     label: "Inativa",
     className: "bg-light-red text-dark-gray",
     dot: "bg-red",
@@ -30,9 +32,9 @@ export function StatusBadge({ status }: StatusProps) {
 
   return (
     <div
-      className={`flex w-24 flex-shrink-0 items-center justify-center gap-2 rounded-full px-3 py-1 font-medium text-sm ${config.className}`}
+      className={cn("flex w-24 flex-shrink-0 items-center justify-center gap-2 rounded-full px-3 py-1 text-sm font-medium", config.className)}
     >
-      <span className={`h-3 w-3 rounded-full ${config.dot}`} />
+      <span className={cn("h-3 w-3 rounded-full", config.dot)} />
       <span>{config.label}</span>
     </div>
   );

--- a/src/features/dashboard/components/Status.tsx
+++ b/src/features/dashboard/components/Status.tsx
@@ -32,7 +32,10 @@ export function StatusBadge({ status }: StatusProps) {
 
   return (
     <div
-      className={cn("flex w-24 flex-shrink-0 items-center justify-center gap-2 rounded-full px-3 py-1 text-sm font-medium", config.className)}
+      className={cn(
+        "flex w-24 flex-shrink-0 items-center justify-center gap-2 rounded-full px-3 py-1 font-medium text-sm",
+        config.className,
+      )}
     >
       <span className={cn("h-3 w-3 rounded-full", config.dot)} />
       <span>{config.label}</span>


### PR DESCRIPTION
- Adiciona o componente de status;
- Disponível com status Ativa, Livre e Inativa;
- Disponíveis com mesmo tamanho, formato e estilo;
- Opção centralizada e não centralizada, fiquei na dúvida;
- Usei a cor amarelo para o status Livre pois não existia light-yellow ou outra no projeto parecida com o Figma, mas achei que ficou mais adequado assim.

teste unitário:
<img width="960" height="492" alt="image" src="https://github.com/user-attachments/assets/a5fc3fb9-2dc0-4f59-8aae-3ab8deb358bf" />

- Apenas fiquei na dúvida qual seria mais adequado:
componentes (texto centralizado):
<img width="491" height="87" alt="image" src="https://github.com/user-attachments/assets/15995173-c131-4346-adce-f3b235122b0d" />

texto não centralizado:
<img width="632" height="87" alt="image" src="https://github.com/user-attachments/assets/8bea354c-2f96-4c70-9f59-63b0652760fd" />