### PR TITLE
chore: audit only prod dependencies

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,9 +1,9 @@
 echo "\n=============================== 🔍 PRE-PUSH CHECK ==============================="
 
-echo "\n > 🛡️ Executing Security Audit"
-bun audit || { echo "\n > ❌ Error: Security vulnerabilities found!\n"; exit 1; }
-
 echo "\n > 🧪 Executing Tests"
 bun test || { echo "\n > ❌ Error: Tests failed!\n"; exit 1; }
+
+echo "\n > 🛡️ Executing Security Audit"
+bun audit --prod || { echo "\n > ❌ Error: Security vulnerabilities found!\n"; exit 1; }
 
 echo "\n > ✅ Success: All checks passed!\n"


### PR DESCRIPTION
Passa a flag `--prod` para validar apenas dependências de produção.

Suprime a vulnerabilidade da dependência da dependência da dependência do commitlint