### PR TITLE
feat: integrar componente de horário com mais entradas

### DIFF
--- a/src/features/dashboard/DashboardService.spec.ts
+++ b/src/features/dashboard/DashboardService.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, mock } from "bun:test";
+import { api } from "@/lib/api";
+import { jsonResponse } from "/test/utils/makeResponse";
+import { DashboardService } from "./DashboardService";
+
+describe("DashboardService", () => {
+  it("should get dashboard metrics", async () => {
+    let observedRequest: Request | undefined;
+    const fetchMock = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      observedRequest = new Request(input, init);
+      return Promise.resolve(
+        jsonResponse({
+          entriesLastHour: 8,
+          exitsLastHour: 3,
+          peakEntryTime: "09:00",
+        }),
+      );
+    });
+    const apiMock = api.extend({ fetch: fetchMock });
+
+    const service = new DashboardService(apiMock);
+    const result = await service.getMetrics();
+
+    if (!observedRequest) throw new Error("Request was not called");
+    expect(observedRequest.url).toContain("/dashboard/metrics");
+    expect(observedRequest.method).toBe("GET");
+    expect(result).toEqual({
+      entriesLastHour: 8,
+      exitsLastHour: 3,
+      peakEntryTime: "09:00",
+    });
+  });
+});

--- a/src/features/dashboard/DashboardService.ts
+++ b/src/features/dashboard/DashboardService.ts
@@ -1,0 +1,19 @@
+import { type ApiClient, api } from "@/lib/api";
+import {
+  type DashboardMetricsDto,
+  dashboardMetricsSchema,
+} from "./dtos/dashboardMetricsDto";
+
+export class DashboardService {
+  private apiClient: Pick<ApiClient, "get">;
+
+  constructor(apiClient: Pick<ApiClient, "get">) {
+    this.apiClient = apiClient;
+  }
+
+  async getMetrics(): Promise<DashboardMetricsDto> {
+    return this.apiClient.get("dashboard/metrics").json(dashboardMetricsSchema);
+  }
+}
+
+export const dashboardService = new DashboardService(api);

--- a/src/features/dashboard/dtos/dashboardMetricsDto.ts
+++ b/src/features/dashboard/dtos/dashboardMetricsDto.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const dashboardMetricsSchema = z.object({
+  entriesLastHour: z.number(),
+  exitsLastHour: z.number(),
+  peakEntryTime: z.string().nullable(),
+});
+
+export type DashboardMetricsDto = z.infer<typeof dashboardMetricsSchema>;

--- a/src/features/dashboard/hooks/useDashboardMetrics.spec.tsx
+++ b/src/features/dashboard/hooks/useDashboardMetrics.spec.tsx
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { DashboardMetricsDto } from "../dtos/dashboardMetricsDto";
+import { dashboardService } from "../DashboardService";
+import { useDashboardMetrics } from "./useDashboardMetrics";
+
+const getMetricsSpy = spyOn(dashboardService, "getMetrics");
+
+const mockMetrics: DashboardMetricsDto = {
+  entriesLastHour: 10,
+  exitsLastHour: 5,
+  peakEntryTime: "14:00",
+};
+
+describe("useDashboardMetrics hook", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    getMetricsSpy.mockClear();
+  });
+
+  const createWrapper = () => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  it("should return dashboard metrics data successfully", async () => {
+    getMetricsSpy.mockResolvedValueOnce(mockMetrics);
+
+    const { result } = renderHook(() => useDashboardMetrics(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockMetrics);
+    expect(getMetricsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should expose error state when the service query fails", async () => {
+    getMetricsSpy.mockRejectedValueOnce(new Error("Request failed"));
+
+    const { result } = renderHook(() => useDashboardMetrics(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(getMetricsSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/dashboard/hooks/useDashboardMetrics.ts
+++ b/src/features/dashboard/hooks/useDashboardMetrics.ts
@@ -1,0 +1,16 @@
+import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
+import { dashboardService } from "../DashboardService";
+import type { DashboardMetricsDto } from "../dtos/dashboardMetricsDto";
+
+type UseDashboardMetricsOptions = Omit<
+  UseQueryOptions<DashboardMetricsDto, Error>,
+  "queryKey" | "queryFn"
+>;
+
+export function useDashboardMetrics(options?: UseDashboardMetricsOptions) {
+  return useQuery<DashboardMetricsDto, Error>({
+    queryKey: ["dashboard", "metrics"],
+    queryFn: () => dashboardService.getMetrics(),
+    ...options,
+  });
+}

--- a/src/features/transactions/hooks/useCreateTransaction.spec.tsx
+++ b/src/features/transactions/hooks/useCreateTransaction.spec.tsx
@@ -40,7 +40,7 @@ describe("useCreateTransaction", () => {
     const invalidateSpy = spyOn(
       queryClient,
       "invalidateQueries",
-    ).mockResolvedValue(undefined as any);
+    ).mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useCreateTransaction(), { wrapper });
 

--- a/src/routes/admin/dashboard.spec.tsx
+++ b/src/routes/admin/dashboard.spec.tsx
@@ -1,0 +1,71 @@
+import "@testing-library/jest-dom";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { Dashboard } from "./dashboard";
+import { dashboardService } from "@/features/dashboard/DashboardService";
+
+const getMetricsMock = spyOn(dashboardService, "getMetrics");
+
+const mockMetrics = {
+  entriesLastHour: 5,
+  exitsLastHour: 2,
+  peakEntryTime: "10:00",
+};
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("Dashboard Route Component", () => {
+  beforeEach(() => {
+    getMetricsMock.mockResolvedValue(mockMetrics);
+  });
+
+  afterEach(() => {
+    cleanup();
+    getMetricsMock.mockClear();
+  });
+
+  it("should render Dashboard page title", () => {
+    render(<Dashboard />, { wrapper: createWrapper() });
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(
+      screen.getByText("Bem-vindo ao painel principal do sistema IMPINJ"),
+    ).toBeInTheDocument();
+  });
+
+  it("should render MetricCard with top label 'Horário com mais entradas'", () => {
+    render(<Dashboard />, { wrapper: createWrapper() });
+    expect(screen.getByText("Horário com mais entradas")).toBeInTheDocument();
+  });
+
+  it("should display peak entry time from API metrics when loaded", async () => {
+    render(<Dashboard />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("10:00")).toBeInTheDocument();
+    });
+  });
+
+  it("should render fallback text when peakEntryTime is null", async () => {
+    getMetricsMock.mockResolvedValue({
+      entriesLastHour: 0,
+      exitsLastHour: 0,
+      peakEntryTime: null,
+    });
+
+    render(<Dashboard />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("--:--")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/routes/admin/dashboard.tsx
+++ b/src/routes/admin/dashboard.tsx
@@ -1,4 +1,9 @@
+import { MetricCard } from "@/features/dashboard/components/dashboardCard";
+import { useDashboardMetrics } from "@/features/dashboard/hooks/useDashboardMetrics";
+
 export function Dashboard() {
+  const { data: metrics } = useDashboardMetrics();
+
   return (
     <div className="p-8">
       <h1 className="mb-4 font-bold text-3xl text-dark-gray">Dashboard</h1>
@@ -6,31 +11,12 @@ export function Dashboard() {
         Bem-vindo ao painel principal do sistema IMPINJ
       </p>
 
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
-        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-          <h3 className="mb-2 font-semibold text-dark-gray text-lg">
-            Veículos Ativos
-          </h3>
-          <p className="font-bold text-3xl text-blue">0</p>
-        </div>
-        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-          <h3 className="mb-2 font-semibold text-dark-gray text-lg">
-            Usuários Cadastrados
-          </h3>
-          <p className="font-bold text-3xl text-teal">0</p>
-        </div>
-        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-          <h3 className="mb-2 font-semibold text-dark-gray text-lg">
-            Etiquetas Emitidas
-          </h3>
-          <p className="font-bold text-3xl text-green">0</p>
-        </div>
-        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-          <h3 className="mb-2 font-semibold text-dark-gray text-lg">
-            Cobranças Pendentes
-          </h3>
-          <p className="font-bold text-3xl text-yellow">0</p>
-        </div>
+      <div className="max-w-[704px]">
+        <MetricCard
+          topLabel="Horário com mais entradas"
+          bottomLabel={metrics?.peakEntryTime ?? "--:--"}
+          size="lg"
+        />
       </div>
     </div>
   );

--- a/src/routes/user/payment.spec.tsx
+++ b/src/routes/user/payment.spec.tsx
@@ -25,40 +25,74 @@ const queryClient = new QueryClient({
   },
 });
 
+const useMeResult = (result: Partial<ReturnType<typeof useMeHook.useMe>>) =>
+  result as ReturnType<typeof useMeHook.useMe>;
+
+const useMyTransactionsResult = (
+  result: Partial<ReturnType<typeof useMyTransactionsHook.useMyTransactions>>,
+) => result as ReturnType<typeof useMyTransactionsHook.useMyTransactions>;
+
+const useCreateTransactionResult = (
+  result: Partial<
+    ReturnType<typeof useCreateTransactionHook.useCreateTransaction>
+  >,
+) => result as ReturnType<typeof useCreateTransactionHook.useCreateTransaction>;
+
+const usePricingResult = (
+  result: Partial<ReturnType<typeof usePricingHook.usePricing>>,
+) => result as ReturnType<typeof usePricingHook.usePricing>;
+
+const mockUser = {
+  userId: "1",
+  name: "Eduardo",
+  email: "eduardo@example.com",
+  role: "customer",
+  balance: 150,
+  vehicles: [],
+} satisfies NonNullable<ReturnType<typeof useMeHook.useMe>["data"]>;
+
 describe("Payment Route", () => {
   beforeEach(() => {
-    spyOn(usePricingHook, "usePricing").mockReturnValue({
-      isLoading: false,
-      isError: false,
-      data: {
-        parkingPriceId: "550e8400-e29b-41d4-a716-446655440000",
-        toleranceMinutes: 15,
-        basePrice: 10,
-        hourlyRate: 5,
-        thresholdMinutes: 180,
-      },
-      refetch: mock(),
-    } as any);
+    spyOn(usePricingHook, "usePricing").mockReturnValue(
+      usePricingResult({
+        isLoading: false,
+        isError: false,
+        data: {
+          parkingPriceId: "550e8400-e29b-41d4-a716-446655440000",
+          toleranceMinutes: 15,
+          basePrice: 10,
+          hourlyRate: 5,
+          thresholdMinutes: 180,
+        },
+        refetch: mock(),
+      }),
+    );
   });
 
   it("should render loading state when user data is loading", () => {
-    spyOn(useMeHook, "useMe").mockReturnValue({
-      isLoading: true,
-      isError: false,
-      data: undefined,
-      refetch: mock(),
-    } as any);
+    spyOn(useMeHook, "useMe").mockReturnValue(
+      useMeResult({
+        isLoading: true,
+        isError: false,
+        data: undefined,
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue({
-      isLoading: false,
-      isError: false,
-      data: [],
-      refetch: mock(),
-    } as any);
+    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue(
+      useMyTransactionsResult({
+        isLoading: false,
+        isError: false,
+        data: [],
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue({
-      mutate: mock(),
-    } as any);
+    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue(
+      useCreateTransactionResult({
+        mutate: mock(),
+      }),
+    );
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -70,23 +104,29 @@ describe("Payment Route", () => {
   });
 
   it("should render error state when user data fetching fails", () => {
-    spyOn(useMeHook, "useMe").mockReturnValue({
-      isLoading: false,
-      isError: true,
-      data: undefined,
-      refetch: mock(),
-    } as any);
+    spyOn(useMeHook, "useMe").mockReturnValue(
+      useMeResult({
+        isLoading: false,
+        isError: true,
+        data: undefined,
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue({
-      isLoading: false,
-      isError: false,
-      data: [],
-      refetch: mock(),
-    } as any);
+    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue(
+      useMyTransactionsResult({
+        isLoading: false,
+        isError: false,
+        data: [],
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue({
-      mutate: mock(),
-    } as any);
+    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue(
+      useCreateTransactionResult({
+        mutate: mock(),
+      }),
+    );
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -100,27 +140,29 @@ describe("Payment Route", () => {
   });
 
   it("should render loading text when transactions are loading", () => {
-    spyOn(useMeHook, "useMe").mockReturnValue({
-      isLoading: false,
-      isError: false,
-      data: {
-        userId: "1",
-        name: "Eduardo",
-        balance: 150,
-      },
-      refetch: mock(),
-    } as any);
+    spyOn(useMeHook, "useMe").mockReturnValue(
+      useMeResult({
+        isLoading: false,
+        isError: false,
+        data: mockUser,
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue({
-      isLoading: true,
-      isError: false,
-      data: undefined,
-      refetch: mock(),
-    } as any);
+    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue(
+      useMyTransactionsResult({
+        isLoading: true,
+        isError: false,
+        data: undefined,
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue({
-      mutate: mock(),
-    } as any);
+    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue(
+      useCreateTransactionResult({
+        mutate: mock(),
+      }),
+    );
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -132,27 +174,29 @@ describe("Payment Route", () => {
   });
 
   it("should render error text when transactions load fails", () => {
-    spyOn(useMeHook, "useMe").mockReturnValue({
-      isLoading: false,
-      isError: false,
-      data: {
-        userId: "1",
-        name: "Eduardo",
-        balance: 150,
-      },
-      refetch: mock(),
-    } as any);
+    spyOn(useMeHook, "useMe").mockReturnValue(
+      useMeResult({
+        isLoading: false,
+        isError: false,
+        data: mockUser,
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue({
-      isLoading: false,
-      isError: true,
-      data: undefined,
-      refetch: mock(),
-    } as any);
+    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue(
+      useMyTransactionsResult({
+        isLoading: false,
+        isError: true,
+        data: undefined,
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue({
-      mutate: mock(),
-    } as any);
+    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue(
+      useCreateTransactionResult({
+        mutate: mock(),
+      }),
+    );
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -166,28 +210,30 @@ describe("Payment Route", () => {
   });
 
   it("should render empty text when user has no transactions", () => {
-    spyOn(useMeHook, "useMe").mockReturnValue({
-      isLoading: false,
-      isError: false,
-      data: {
-        userId: "1",
-        name: "Eduardo",
-        balance: 150,
-      },
-      refetch: mock(),
-    } as any);
+    spyOn(useMeHook, "useMe").mockReturnValue(
+      useMeResult({
+        isLoading: false,
+        isError: false,
+        data: mockUser,
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue({
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-      data: [],
-      refetch: mock(),
-    } as any);
+    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue(
+      useMyTransactionsResult({
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+        data: [],
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue({
-      mutate: mock(),
-    } as any);
+    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue(
+      useCreateTransactionResult({
+        mutate: mock(),
+      }),
+    );
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -201,45 +247,47 @@ describe("Payment Route", () => {
   });
 
   it("should render transaction cards for deposit and withdrawal", () => {
-    spyOn(useMeHook, "useMe").mockReturnValue({
-      isLoading: false,
-      isError: false,
-      data: {
-        userId: "1",
-        name: "Eduardo",
-        balance: 150,
-      },
-      refetch: mock(),
-    } as any);
+    spyOn(useMeHook, "useMe").mockReturnValue(
+      useMeResult({
+        isLoading: false,
+        isError: false,
+        data: mockUser,
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue({
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-      data: [
-        {
-          transactionId: "t1",
-          transactionType: "deposit",
-          amount: 50,
-          createdAt: new Date().toISOString(),
-          userId: "1",
-          description: "Depósito PIX",
-        },
-        {
-          transactionId: "t2",
-          transactionType: "withdrawal",
-          amount: 15.5,
-          createdAt: new Date().toISOString(),
-          userId: "1",
-          description: "Saída de veículo com placa ABC1234",
-        },
-      ],
-      refetch: mock(),
-    } as any);
+    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue(
+      useMyTransactionsResult({
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+        data: [
+          {
+            transactionId: "t1",
+            transactionType: "deposit",
+            amount: 50,
+            createdAt: new Date().toISOString(),
+            userId: "1",
+            description: "Depósito PIX",
+          },
+          {
+            transactionId: "t2",
+            transactionType: "withdrawal",
+            amount: 15.5,
+            createdAt: new Date().toISOString(),
+            userId: "1",
+            description: "Saída de veículo com placa ABC1234",
+          },
+        ],
+        refetch: mock(),
+      }),
+    );
 
-    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue({
-      mutate: mock(),
-    } as any);
+    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue(
+      useCreateTransactionResult({
+        mutate: mock(),
+      }),
+    );
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -261,33 +309,46 @@ describe("Payment Route", () => {
     const refetchMeMock = mock();
     const refetchTransactionsMock = mock();
 
-    spyOn(useMeHook, "useMe").mockReturnValue({
-      isLoading: false,
-      isError: false,
-      data: {
-        userId: "1",
-        name: "Eduardo",
-        balance: 150,
+    spyOn(useMeHook, "useMe").mockReturnValue(
+      useMeResult({
+        isLoading: false,
+        isError: false,
+        data: mockUser,
+        refetch: refetchMeMock,
+      }),
+    );
+
+    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue(
+      useMyTransactionsResult({
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+        data: [],
+        refetch: refetchTransactionsMock,
+      }),
+    );
+
+    type CreateTransactionMutate = ReturnType<
+      typeof useCreateTransactionHook.useCreateTransaction
+    >["mutate"];
+    type CreateTransactionPayload = Parameters<CreateTransactionMutate>[0];
+    type CreateTransactionOptions = Parameters<CreateTransactionMutate>[1];
+
+    let mutateOptions: CreateTransactionOptions;
+    const mutateMock = mock(
+      (
+        _payload: CreateTransactionPayload,
+        options?: CreateTransactionOptions,
+      ) => {
+        mutateOptions = options;
       },
-      refetch: refetchMeMock,
-    } as any);
+    );
 
-    spyOn(useMyTransactionsHook, "useMyTransactions").mockReturnValue({
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-      data: [],
-      refetch: refetchTransactionsMock,
-    } as any);
-
-    let mutateOptions: any;
-    const mutateMock = mock((_payload, options) => {
-      mutateOptions = options;
-    });
-
-    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue({
-      mutate: mutateMock,
-    } as any);
+    spyOn(useCreateTransactionHook, "useCreateTransaction").mockReturnValue(
+      useCreateTransactionResult({
+        mutate: mutateMock,
+      }),
+    );
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -323,13 +384,15 @@ describe("Payment Route", () => {
     });
 
     const toastSuccessSpy = spyOn(toast, "success");
-    mutateOptions.onSuccess();
+    const onSuccess = mutateOptions?.onSuccess as (() => void) | undefined;
+    onSuccess?.();
     expect(toastSuccessSpy).toHaveBeenCalled();
     expect(refetchMeMock).toHaveBeenCalled();
     expect(refetchTransactionsMock).toHaveBeenCalled();
 
     const toastErrorSpy = spyOn(toast, "error");
-    mutateOptions.onError();
+    const onError = mutateOptions?.onError as (() => void) | undefined;
+    onError?.();
     expect(toastErrorSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Resumo

Este PR integra o card **“Horário com mais entradas”** ao dashboard administrativo, utilizando o componente `MetricCard` conforme solicitado na issue.

A informação exibida passa a ser consumida diretamente do backend por meio do endpoint de métricas do dashboard, garantindo que o card reflita dados atualizados da aplicação. Quando o backend retorna `peakEntryTime` como `null`, ou seja, quando ainda não há registros suficientes para calcular o horário com mais entradas, o frontend exibe `--:--` como estado vazio.

Também foram realizados ajustes em testes para remover tipagens fracas e manter o projeto alinhado às validações de lint e typecheck.

## Alterações realizadas

- Integração do card “Horário com mais entradas” no dashboard usando `MetricCard`.
- Criação do serviço/hook para buscar métricas atualizadas do backend.
- Tratamento de `peakEntryTime: null` exibindo `--:--`.
- Ajustes em specs para remover usos desnecessários de `any`.

## Provas

<img width="1083" height="604" alt="Captura de Tela 2026-05-29 às 23 06 03" src="https://github.com/user-attachments/assets/5f3858da-5137-4afc-9704-ef67fef0ad8e" />

## Validações

- `bun check`
- `bun test`
- `bun run build`