### PR TITLE
fix: allow clearing parking price numeric inputs

### DIFF
--- a/src/features/parking-prices/components/EditValuesModal.spec.tsx
+++ b/src/features/parking-prices/components/EditValuesModal.spec.tsx
@@ -147,6 +147,28 @@ describe("EditValuesModal", () => {
     });
   });
 
+  it("allows clearing numeric inputs before typing a new value", async () => {
+    render(<EditValuesModal isOpen={true} onClose={() => {}} />, {
+      wrapper: createWrapper(),
+    });
+
+    const basePriceInput = await screen.findByLabelText(
+      "Valor até 3 horas (R$)",
+    );
+
+    fireEvent.change(basePriceInput, {
+      target: { value: "" },
+    });
+
+    expect(basePriceInput).toHaveValue(null);
+
+    fireEvent.change(basePriceInput, {
+      target: { value: "35" },
+    });
+
+    expect(basePriceInput).toHaveValue(35);
+  });
+
   it("calls onClose when cancel button is clicked", () => {
     const onCloseMock = mock(() => {});
 

--- a/src/features/parking-prices/components/EditValuesModal.tsx
+++ b/src/features/parking-prices/components/EditValuesModal.tsx
@@ -25,15 +25,15 @@ export function EditValuesModal({ isOpen, onClose }: EditValuesModalProps) {
   const { data: pricing } = usePricing();
   const { mutate: updatePricing, isPending } = useUpdatePricing();
 
-  const [toleranceMinutes, setToleranceMinutes] = useState<number>(15);
-  const [basePrice, setBasePrice] = useState<number>(15.0);
-  const [hourlyRate, setHourlyRate] = useState<number>(5.0);
+  const [toleranceMinutes, setToleranceMinutes] = useState("15");
+  const [basePrice, setBasePrice] = useState("15");
+  const [hourlyRate, setHourlyRate] = useState("5");
 
   useEffect(() => {
     if (pricing) {
-      setToleranceMinutes(pricing.toleranceMinutes);
-      setBasePrice(pricing.basePrice);
-      setHourlyRate(pricing.hourlyRate);
+      setToleranceMinutes(String(pricing.toleranceMinutes));
+      setBasePrice(String(pricing.basePrice));
+      setHourlyRate(String(pricing.hourlyRate));
     }
   }, [pricing]);
 
@@ -45,9 +45,9 @@ export function EditValuesModal({ isOpen, onClose }: EditValuesModalProps) {
       {
         parkingPriceId: pricing.parkingPriceId,
         updateDto: {
-          toleranceMinutes,
-          basePrice,
-          hourlyRate,
+          toleranceMinutes: Number(toleranceMinutes),
+          basePrice: Number(basePrice),
+          hourlyRate: Number(hourlyRate),
         },
       },
       {
@@ -73,7 +73,7 @@ export function EditValuesModal({ isOpen, onClose }: EditValuesModalProps) {
             type="number"
             className="w-full rounded-md border border-gray-300 px-3 py-2"
             value={toleranceMinutes}
-            onChange={(e) => setToleranceMinutes(Number(e.target.value))}
+            onChange={(e) => setToleranceMinutes(e.target.value)}
             required
             min="0"
           />
@@ -92,7 +92,7 @@ export function EditValuesModal({ isOpen, onClose }: EditValuesModalProps) {
             step="0.01"
             className="w-full rounded-md border border-gray-300 px-3 py-2"
             value={basePrice}
-            onChange={(e) => setBasePrice(Number(e.target.value))}
+            onChange={(e) => setBasePrice(e.target.value)}
             required
             min="0"
           />
@@ -111,7 +111,7 @@ export function EditValuesModal({ isOpen, onClose }: EditValuesModalProps) {
             step="0.01"
             className="w-full rounded-md border border-gray-300 px-3 py-2"
             value={hourlyRate}
-            onChange={(e) => setHourlyRate(Number(e.target.value))}
+            onChange={(e) => setHourlyRate(e.target.value)}
             required
             min="0"
           />

--- a/src/features/parking-prices/components/EditValuesModal.tsx
+++ b/src/features/parking-prices/components/EditValuesModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
+import { parseNumber } from "@/utils/parseNumber";
 import { usePricing, useUpdatePricing } from "../hooks";
 
 interface EditValuesModalProps {
@@ -41,20 +42,22 @@ export function EditValuesModal({ isOpen, onClose }: EditValuesModalProps) {
     e.preventDefault();
     if (!pricing?.parkingPriceId) return;
 
+    const tolerance = parseNumber(toleranceMinutes);
+    const base = parseNumber(basePrice);
+    const hourly = parseNumber(hourlyRate);
+
+    if (tolerance === null || base === null || hourly === null) return;
+
     updatePricing(
       {
         parkingPriceId: pricing.parkingPriceId,
         updateDto: {
-          toleranceMinutes: Number(toleranceMinutes),
-          basePrice: Number(basePrice),
-          hourlyRate: Number(hourlyRate),
+          toleranceMinutes: tolerance,
+          basePrice: base,
+          hourlyRate: hourly,
         },
       },
-      {
-        onSuccess: () => {
-          onClose();
-        },
-      },
+      { onSuccess: onClose },
     );
   };
 

--- a/src/utils/parseNumber.spec.ts
+++ b/src/utils/parseNumber.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { parseNumber } from "./parseNumber";
+
+describe("parseNumber", () => {
+  it("should parse a valid number", () => {
+    const result = parseNumber("42");
+    expect(result).toBe(42);
+  });
+
+  it("should return null for an empty string", () => {
+    const result = parseNumber("");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for a string with only whitespace", () => {
+    const result = parseNumber("   ");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for an invalid number", () => {
+    const result = parseNumber("abc");
+    expect(result).toBeNull();
+  });
+});

--- a/src/utils/parseNumber.ts
+++ b/src/utils/parseNumber.ts
@@ -1,0 +1,5 @@
+export function parseNumber(v: string): number | null {
+  if (v.trim() === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}


### PR DESCRIPTION
## O que foi feito

Corrige o comportamento dos campos numéricos no modal de edição de valores do estacionamento.

Antes, ao apagar o valor de um campo, o formulário convertia a string vazia (`""`) para `0` imediatamente, impedindo o usuário de limpar o campo antes de digitar um novo valor. (Percebi isso ao testar o sistema).

Agora, os inputs mantêm o valor como texto durante a edição e convertem para número apenas no envio do formulário.

## Antes
<img width="435" height="336" alt="Captura de Tela 2026-05-31 às 14 57 40" src="https://github.com/user-attachments/assets/c07af82b-2843-46b9-bfd7-b7516a121a9f" />

## Depois
<img width="432" height="337" alt="Captura de Tela 2026-05-31 às 14 58 02" src="https://github.com/user-attachments/assets/ad59f34b-1aa1-4e55-a7d3-56f09b097149" />

- Adicionado teste cobrindo o cenário de limpar um campo numérico e digitar um novo valor.
- `bun run typecheck`
- `bun test`


Autorizado a fazer o Hotfix pelo @eduardo-de-bastiani .