### PR TITLE
feat: add edit occupancy mode

### DIFF
--- a/src/features/dashboard/components/parking-occupancy-card/index.tsx
+++ b/src/features/dashboard/components/parking-occupancy-card/index.tsx
@@ -1,10 +1,15 @@
+import { useState } from "react";
 import { cn } from "@/utils/cn";
+import { Pencil } from "lucide-react";
+import { EditCapacityModal } from "@/features/vehicles/components/EditCapacityModal";
 
 type ParkingOccupancyCardProps = {
   title?: string;
   vehiclesCount: number;
   totalSpots: number;
   className?: string;
+  isEditable?: boolean;
+  onEditCapacity?: (newCapacity: number) => void;
 };
 
 function getProgressBarColor(rawPercentage: number) {
@@ -24,7 +29,11 @@ export function ParkingOccupancyCard({
   vehiclesCount,
   totalSpots,
   className,
+  isEditable = false,
+  onEditCapacity,
 }: Readonly<ParkingOccupancyCardProps>) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   const safeTotalSpots = Math.max(totalSpots, 0);
 
   const rawPercentage =
@@ -34,6 +43,12 @@ export function ParkingOccupancyCard({
 
   const progressBarColor = getProgressBarColor(rawPercentage);
 
+  const handleConfirm = (newCapacity: number) => {
+    if (onEditCapacity) {
+      onEditCapacity(newCapacity);
+    }
+  };
+
   return (
     <section
       data-testid="parking-occupancy-card"
@@ -42,13 +57,26 @@ export function ParkingOccupancyCard({
         className,
       )}
     >
-      <h2
-        data-testid="parking-occupancy-title"
-        className="font-bold text-[32px] text-black"
-      >
-        {title}
-      </h2>
+      <div className="flex items-center justify-between">
+        <h2
+          data-testid="parking-occupancy-title"
+          className="font-bold text-[32px] text-black"
+        >
+          {title}
+        </h2>
 
+        {isEditable && (
+          <button
+            type="button"
+            data-testid="edit-capacity-button"
+            onClick={() => setIsModalOpen(true)}
+            className="flex items-center justify-center rounded-full p-2 text-zinc-600 transition-all hover:bg-zinc-100 hover:text-[#1f304c]"
+            title="Editar lotação"
+          >
+            <Pencil className="h-6 w-6" strokeWidth={2.5} />
+          </button>
+        )}
+      </div>
       <div className="mt-8 flex items-center gap-8">
         <div
           data-testid="parking-occupancy-progress-track"
@@ -63,7 +91,6 @@ export function ParkingOccupancyCard({
             }}
           />
         </div>
-
         <span
           data-testid="parking-occupancy-label"
           className="min-w-fit font-bold text-[56px] text-black leading-none"
@@ -71,6 +98,15 @@ export function ParkingOccupancyCard({
           {vehiclesCount}/{totalSpots}
         </span>
       </div>
+
+      {isEditable && (
+        <EditCapacityModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          onConfirm={handleConfirm}
+          currentCapacity={totalSpots}
+        />
+      )}
     </section>
   );
 }

--- a/src/features/dashboard/components/parking-occupancy-card/index.tsx
+++ b/src/features/dashboard/components/parking-occupancy-card/index.tsx
@@ -70,7 +70,7 @@ export function ParkingOccupancyCard({
             type="button"
             data-testid="edit-capacity-button"
             onClick={() => setIsModalOpen(true)}
-            className="flex items-center justify-center rounded-full p-2 text-zinc-600 transition-all hover:bg-zinc-100 hover:text-[#1f304c]"
+            className="flex items-center justify-center rounded-full p-2 text-dark-gray transition-all hover:bg-gray/10 hover:text-dark-gray"
             title="Editar lotação"
           >
             <Pencil className="h-6 w-6" strokeWidth={2.5} />

--- a/src/features/dashboard/components/parking-occupancy-card/parking-occupancy-card.spec.tsx
+++ b/src/features/dashboard/components/parking-occupancy-card/parking-occupancy-card.spec.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
-import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, mock } from "bun:test";
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
 import { ParkingOccupancyCard } from ".";
 
 afterEach(() => {
@@ -96,5 +96,38 @@ describe("ParkingOccupancyCard", () => {
 
     const progressBar = screen.getByTestId("parking-occupancy-progress-bar");
     expect(progressBar).toHaveStyle("width: 0%");
+  });
+
+  test("should open edit modal and call onEditCapacity when isEditable is true", () => {
+    const onEditCapacityMock = mock();
+
+    render(
+      <ParkingOccupancyCard
+        vehiclesCount={10}
+        totalSpots={100}
+        isEditable={true}
+        onEditCapacity={onEditCapacityMock}
+      />,
+    );
+
+    const editButton = screen.getByTestId("edit-capacity-button");
+    fireEvent.click(editButton);
+
+    expect(screen.getByText("Editar lotação")).toBeTruthy();
+
+    const input = screen.getByLabelText("Número de vagas");
+    fireEvent.change(input, { target: { value: "200" } });
+
+    const confirmButton = screen.getByText("Confirmar");
+    fireEvent.click(confirmButton);
+
+    expect(onEditCapacityMock).toHaveBeenCalledWith(200);
+  });
+
+  test("should not render the edit button when isEditable is false", () => {
+    render(<ParkingOccupancyCard vehiclesCount={10} totalSpots={100} />);
+
+    const editButton = screen.queryByTestId("edit-capacity-button");
+    expect(editButton).toBeNull();
   });
 });

--- a/src/features/vehicles/components/EditCapacityModal.spec.tsx
+++ b/src/features/vehicles/components/EditCapacityModal.spec.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach, mock } from "bun:test";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { EditCapacityModal } from "./EditCapacityModal";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("EditCapacityModal", () => {
+  it("should not render anything when isOpen is false", () => {
+    render(
+      <EditCapacityModal isOpen={false} onClose={mock()} onConfirm={mock()} />,
+    );
+    expect(screen.queryByText("Editar lotação")).toBeNull();
+  });
+
+  it("should render correctly with the initial capacity", () => {
+    render(
+      <EditCapacityModal
+        isOpen={true}
+        onClose={mock()}
+        onConfirm={mock()}
+        currentCapacity={150}
+      />,
+    );
+
+    expect(screen.getByText("Editar lotação")).toBeTruthy();
+    expect(screen.getByText("Número de vagas")).toBeTruthy();
+
+    const input = screen.getByLabelText("Número de vagas") as HTMLInputElement;
+    expect(input.value).toBe("150");
+  });
+
+  it("should update the input value when the user types", () => {
+    render(
+      <EditCapacityModal
+        isOpen={true}
+        onClose={mock()}
+        onConfirm={mock()}
+        currentCapacity={100}
+      />,
+    );
+
+    const input = screen.getByLabelText("Número de vagas") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "250" } });
+
+    expect(input.value).toBe("250");
+  });
+
+  it("should call onClose when the Cancel button is clicked", () => {
+    const onCloseMock = mock();
+    render(
+      <EditCapacityModal
+        isOpen={true}
+        onClose={onCloseMock}
+        onConfirm={mock()}
+      />,
+    );
+
+    const cancelButton = screen.getByText("Cancelar");
+    fireEvent.click(cancelButton);
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onConfirm with the new capacity and close the modal when Confirm is clicked", () => {
+    const onConfirmMock = mock();
+    const onCloseMock = mock();
+
+    render(
+      <EditCapacityModal
+        isOpen={true}
+        onClose={onCloseMock}
+        onConfirm={onConfirmMock}
+        currentCapacity={100}
+      />,
+    );
+
+    const input = screen.getByLabelText("Número de vagas");
+    fireEvent.change(input, { target: { value: "300" } });
+
+    const confirmButton = screen.getByText("Confirmar");
+    fireEvent.click(confirmButton);
+
+    expect(onConfirmMock).toHaveBeenCalledWith(300);
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not call onConfirm if the capacity is a negative number", () => {
+    const onConfirmMock = mock();
+    const onCloseMock = mock();
+
+    render(
+      <EditCapacityModal
+        isOpen={true}
+        onClose={onCloseMock}
+        onConfirm={onConfirmMock}
+      />,
+    );
+
+    const input = screen.getByLabelText("Número de vagas");
+
+    fireEvent.change(input, { target: { value: "-50" } });
+
+    const confirmButton = screen.getByText("Confirmar");
+    fireEvent.click(confirmButton);
+
+    expect(onConfirmMock).not.toHaveBeenCalled();
+    expect(onCloseMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/vehicles/components/EditCapacityModal.tsx
+++ b/src/features/vehicles/components/EditCapacityModal.tsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from "react";
+
+interface EditCapacityModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (newCapacity: number) => void;
+  currentCapacity?: number;
+}
+export function EditCapacityModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  currentCapacity = 100,
+}: EditCapacityModalProps) {
+  const [capacity, setCapacity] = useState<number | string>(currentCapacity);
+  useEffect(() => {
+    if (isOpen) {
+      setCapacity(currentCapacity);
+    }
+  }, [isOpen, currentCapacity]);
+  if (!isOpen) return null;
+
+  const handleConfirm = () => {
+    const parsedValue = Number(capacity);
+
+    if (!Number.isNaN(parsedValue) && parsedValue >= 0) {
+      onConfirm(parsedValue);
+      onClose();
+    }
+  };
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-[420px] rounded-xl bg-white p-8 shadow-xl">
+        <h2 className="mb-8 text-center font-bold text-2xl text-dark-blue">
+          Editar lotação
+        </h2>
+        <div className="mb-10">
+          <label
+            htmlFor="capacity-input"
+            className="mb-2 block font-bold text-zinc-800"
+          >
+            Número de vagas
+          </label>
+          <input
+            id="capacity-input"
+            type="number"
+            min="0"
+            value={capacity}
+            onChange={(e) => setCapacity(e.target.value)}
+            className="w-full rounded-lg border border-zinc-300 p-3 text-lg text-zinc-800 outline-none transition-all focus:border-dark-blue focus:ring-1 focus:ring-dark-blue"
+          />
+        </div>
+
+        <div className="flex items-center justify-end gap-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 font-bold text-zinc-800 transition-colors hover:text-black"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            className="rounded-lg bg-dark-blue px-6 py-3 font-bold text-white transition-colors hover:bg-dark-blue"
+          >
+            Confirmar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/vehicles/components/EditCapacityModal.tsx
+++ b/src/features/vehicles/components/EditCapacityModal.tsx
@@ -37,7 +37,7 @@ export function EditCapacityModal({
         <div className="mb-10">
           <label
             htmlFor="capacity-input"
-            className="mb-2 block font-bold text-zinc-800"
+            className="mb-2 block font-bold text-dark-gray"
           >
             Número de vagas
           </label>
@@ -47,7 +47,7 @@ export function EditCapacityModal({
             min="0"
             value={capacity}
             onChange={(e) => setCapacity(e.target.value)}
-            className="w-full rounded-lg border border-zinc-300 p-3 text-lg text-zinc-800 outline-none transition-all focus:border-dark-blue focus:ring-1 focus:ring-dark-blue"
+            className="w-full rounded-lg border border-light-gray p-3 text-dark-gray text-lg outline-none transition-all focus:border-dark-blue focus:ring-1 focus:ring-dark-blue"
           />
         </div>
 
@@ -55,14 +55,14 @@ export function EditCapacityModal({
           <button
             type="button"
             onClick={onClose}
-            className="px-4 py-2 font-bold text-zinc-800 transition-colors hover:text-black"
+            className="px-4 py-2 font-bold text-dark-gray transition-colors hover:text-black"
           >
             Cancelar
           </button>
           <button
             type="button"
             onClick={handleConfirm}
-            className="rounded-lg bg-dark-blue px-6 py-3 font-bold text-white transition-colors hover:bg-dark-blue"
+            className="rounded-lg bg-dark-blue px-6 py-3 font-bold text-white transition-colors hover:bg-dark-blue-75"
           >
             Confirmar
           </button>


### PR DESCRIPTION
## **Task #144 - Modal de editar lotação da tela de sistema do administrador.**

- Criação do modal de edição integrado ao componente de lotação de veículos.
-  Reaproveitamento do componente de lotação (originalmente do Dashboard). Foi adicionada a propriedade isEditable, garantindo que ele continue estático no Dashboard, mas habilite a opção de edição na tela de Sistema.
- Todos testes passaram e a maioria está com cobertura acima de 90%.

### Imagem do componente de lotação reutilizado com a opção de edição:
<img width="676" height="205" alt="lotacaoVerdeAges" src="https://github.com/user-attachments/assets/839faceb-0c29-4bc1-afe6-a730c4071fd7" />

### Imagem do modal de editar lotação pronto:
<img width="463" height="333" alt="modalLotacaoAges" src="https://github.com/user-attachments/assets/1640081b-e1b5-4e25-b787-7f1684b93097" />

