### PR TITLE
feat(tags): update tags table and modals to show TID and EPC

### DIFF
--- a/src/features/auth/AuthService.spec.ts
+++ b/src/features/auth/AuthService.spec.ts
@@ -1,9 +1,9 @@
 /** biome-ignore-all lint/style/noNonNullAssertion: Needed for array destructuring */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { type ApiClient, api } from "@/lib/api";
+import { type ApiClient, api, TOKEN_KEY } from "@/lib/api";
 import { jsonResponse } from "/test/utils/makeResponse";
 import type { UserDto } from "../users/dtos";
-import { AuthService, TOKEN_KEY } from "./AuthService";
+import { AuthService } from "./AuthService";
 import type { LoginDto } from "./dtos";
 
 const mockUser: UserDto = {

--- a/src/features/auth/AuthService.ts
+++ b/src/features/auth/AuthService.ts
@@ -1,5 +1,5 @@
 import { isHTTPError } from "ky";
-import { type ApiClient, api } from "@/lib/api";
+import { type ApiClient, api, TOKEN_KEY } from "@/lib/api";
 import {
   type UserWithVehiclesDto,
   userWithVehiclesSchema,
@@ -9,8 +9,6 @@ import {
   authResponseSchema,
   type LoginDto,
 } from "./dtos";
-
-export const TOKEN_KEY = "rfid-auth-token";
 
 export class AuthService {
   private readonly apiClient: ApiClient;

--- a/src/features/tags/TagService.spec.ts
+++ b/src/features/tags/TagService.spec.ts
@@ -5,12 +5,16 @@ import { TagService } from "./TagService";
 
 const mockTag = {
   tagId: "tag-001",
+  tid: "TID-001",
+  epc: "EPC-001",
   status: "AVAILABLE",
   vehicleId: null,
 };
 
 const mockTagListItem = {
-  id: "tag-001",
+  tagId: "tag-001",
+  tid: "TID-001",
+  epc: "EPC-001",
   userName: "John Doe",
   plate: "ABC-1234",
   status: "AVAILABLE",
@@ -48,7 +52,7 @@ describe("TagService", () => {
       const result = await tagService.listTags();
 
       expect(result).toHaveLength(1);
-      expect(result[0]?.id).toBe("tag-001");
+      expect(result[0]?.tagId).toBe("tag-001");
       expect(result[0]?.status).toBe("AVAILABLE");
     });
 
@@ -89,7 +93,7 @@ describe("TagService", () => {
     });
 
     it("should call POST /tags with the correct payload", async () => {
-      const createTagDto = { tagId: "tag-999" };
+      const createTagDto = { tid: "TID-999", epc: "EPC-999" };
       fetchMock.mockImplementationOnce(async () => jsonResponse(mockTag));
 
       await tagService.createTag(createTagDto);
@@ -106,7 +110,10 @@ describe("TagService", () => {
     it("should return the created tag with correct data", async () => {
       fetchMock.mockImplementationOnce(async () => jsonResponse(mockTag));
 
-      const result = await tagService.createTag({ tagId: "tag-001" });
+      const result = await tagService.createTag({
+        tid: "TID-001",
+        epc: "EPC-001",
+      });
 
       expect(result.tagId).toBe("tag-001");
       expect(result.status).toBe("AVAILABLE");
@@ -117,7 +124,9 @@ describe("TagService", () => {
         jsonResponse({ invalid: true }),
       );
 
-      expect(tagService.createTag({ tagId: "tag-001" })).rejects.toBeDefined();
+      expect(
+        tagService.createTag({ tid: "TID-001", epc: "EPC-001" }),
+      ).rejects.toBeDefined();
     });
   });
 

--- a/src/features/tags/TagService.spec.ts
+++ b/src/features/tags/TagService.spec.ts
@@ -5,16 +5,16 @@ import { TagService } from "./TagService";
 
 const mockTag = {
   tagId: "tag-001",
-  tid: "TID-001",
-  epc: "EPC-001",
+  tid: "E20034120130000000000001",
+  epc: "300833B2DDD9014000000001",
   status: "AVAILABLE",
   vehicleId: null,
 };
 
 const mockTagListItem = {
   tagId: "tag-001",
-  tid: "TID-001",
-  epc: "EPC-001",
+  tid: "E20034120130000000000001",
+  epc: "300833B2DDD9014000000001",
   userName: "John Doe",
   plate: "ABC-1234",
   status: "AVAILABLE",
@@ -93,7 +93,10 @@ describe("TagService", () => {
     });
 
     it("should call POST /tags with the correct payload", async () => {
-      const createTagDto = { tid: "TID-999", epc: "EPC-999" };
+      const createTagDto = {
+        tid: "E20034120130000000000999",
+        epc: "300833B2DDD9014000000999",
+      };
       fetchMock.mockImplementationOnce(async () => jsonResponse(mockTag));
 
       await tagService.createTag(createTagDto);
@@ -111,8 +114,8 @@ describe("TagService", () => {
       fetchMock.mockImplementationOnce(async () => jsonResponse(mockTag));
 
       const result = await tagService.createTag({
-        tid: "TID-001",
-        epc: "EPC-001",
+        tid: "E20034120130000000000001",
+        epc: "300833B2DDD9014000000001",
       });
 
       expect(result.tagId).toBe("tag-001");
@@ -125,7 +128,10 @@ describe("TagService", () => {
       );
 
       expect(
-        tagService.createTag({ tid: "TID-001", epc: "EPC-001" }),
+        tagService.createTag({
+          tid: "E20034120130000000000001",
+          epc: "300833B2DDD9014000000001",
+        }),
       ).rejects.toBeDefined();
     });
   });

--- a/src/features/tags/components/TagAddModal.spec.tsx
+++ b/src/features/tags/components/TagAddModal.spec.tsx
@@ -1,0 +1,193 @@
+import "@testing-library/jest-dom";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { toast } from "@/components/ui/toast";
+import * as tagHooks from "../hooks";
+
+const createTagMock = mock();
+const useCreateTagSpy = spyOn(tagHooks, "useCreateTag");
+const toastSuccessSpy = spyOn(toast, "success");
+const toastErrorSpy = spyOn(toast, "error");
+
+useCreateTagSpy.mockImplementation(
+  () =>
+    ({
+      mutateAsync: createTagMock,
+      isPending: false,
+    }) as never,
+);
+
+const { TagAddModal } = await import("./TagAddModal");
+
+function renderModal(isOpen = true) {
+  return render(<TagAddModal isOpen={isOpen} onClose={mock()} />);
+}
+
+function renderModalWithClose(onClose: () => void, isOpen = true) {
+  return render(<TagAddModal isOpen={isOpen} onClose={onClose} />);
+}
+
+describe("TagAddModal component", () => {
+  beforeEach(() => {
+    createTagMock.mockClear();
+    toastSuccessSpy.mockClear();
+    toastErrorSpy.mockClear();
+    useCreateTagSpy.mockImplementation(
+      () =>
+        ({
+          mutateAsync: createTagMock,
+          isPending: false,
+        }) as never,
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  afterAll(() => {
+    useCreateTagSpy.mockRestore();
+    toastSuccessSpy.mockRestore();
+    toastErrorSpy.mockRestore();
+  });
+
+  it("should not render when isOpen is false", () => {
+    renderModal(false);
+
+    expect(
+      screen.queryByText("Adicionar etiqueta RFID"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("TID")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("EPC")).not.toBeInTheDocument();
+  });
+
+  it("should render the form fields and actions when open", () => {
+    renderModal();
+
+    expect(screen.getByLabelText("TID")).toBeInTheDocument();
+    expect(screen.getByLabelText("EPC")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Cancelar" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Confirmar" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should call onClose and clear inputs when Cancelar is clicked", () => {
+    const onClose = mock();
+    renderModalWithClose(onClose);
+
+    const tidInput = screen.getByLabelText("TID") as HTMLInputElement;
+    const epcInput = screen.getByLabelText("EPC") as HTMLInputElement;
+
+    act(() => {
+      fireEvent.change(tidInput, { target: { value: "TID-001" } });
+      fireEvent.change(epcInput, { target: { value: "EPC-001" } });
+      fireEvent.click(screen.getByRole("button", { name: "Cancelar" }));
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(tidInput).toHaveValue("");
+    expect(epcInput).toHaveValue("");
+  });
+
+  it("should show an error when TID or EPC is empty", () => {
+    renderModal();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Confirmar" }));
+    });
+
+    expect(toastErrorSpy).toHaveBeenCalledTimes(1);
+    expect(toastErrorSpy).toHaveBeenCalledWith(
+      "Preencha o TID e o EPC da etiqueta.",
+    );
+    expect(createTagMock).not.toHaveBeenCalled();
+  });
+
+  it("should submit the form successfully and close on success", async () => {
+    createTagMock.mockImplementationOnce(async () => Promise.resolve());
+    const onClose = mock();
+    renderModalWithClose(onClose);
+
+    fireEvent.change(screen.getByLabelText("TID"), {
+      target: { value: "TID-001" },
+    });
+    fireEvent.change(screen.getByLabelText("EPC"), {
+      target: { value: "EPC-001" },
+    });
+
+    await fireEvent.submit(
+      screen.getByRole("button", { name: "Confirmar" }).closest("form")!,
+    );
+
+    await createTagMock.mock.results[0]?.value;
+
+    expect(createTagMock).toHaveBeenCalledTimes(1);
+    expect(createTagMock.mock.calls[0]?.[0]).toEqual({
+      tid: "TID-001",
+      epc: "EPC-001",
+    });
+    expect(toastSuccessSpy).toHaveBeenCalledWith(
+      "Etiqueta adicionada com sucesso.",
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show an error when submission fails", async () => {
+    createTagMock.mockImplementationOnce(async () => {
+      throw new Error("Failed");
+    });
+    renderModal();
+
+    fireEvent.change(screen.getByLabelText("TID"), {
+      target: { value: "TID-001" },
+    });
+    fireEvent.change(screen.getByLabelText("EPC"), {
+      target: { value: "EPC-001" },
+    });
+
+    await fireEvent.submit(
+      screen.getByRole("button", { name: "Confirmar" }).closest("form")!,
+    );
+
+    await createTagMock.mock.results[0]?.value.catch(() => undefined);
+
+    expect(toastErrorSpy).toHaveBeenCalledTimes(1);
+    expect(toastErrorSpy).toHaveBeenCalledWith(
+      "Erro ao adicionar etiqueta. Verifique os campos e tente novamente.",
+    );
+  });
+
+  it("should disable the submit button while the request is pending", () => {
+    useCreateTagSpy.mockImplementationOnce(
+      () =>
+        ({
+          mutateAsync: createTagMock,
+          isPending: true,
+        }) as never,
+    );
+
+    renderModal();
+
+    expect(
+      screen.getByRole("button", { name: "Confirmando..." }),
+    ).toBeDisabled();
+  });
+});

--- a/src/features/tags/components/TagAddModal.spec.tsx
+++ b/src/features/tags/components/TagAddModal.spec.tsx
@@ -97,8 +97,12 @@ describe("TagAddModal component", () => {
     const epcInput = screen.getByLabelText("EPC") as HTMLInputElement;
 
     act(() => {
-      fireEvent.change(tidInput, { target: { value: "TID-001" } });
-      fireEvent.change(epcInput, { target: { value: "EPC-001" } });
+      fireEvent.change(tidInput, {
+        target: { value: "E20034120130000000000001" },
+      });
+      fireEvent.change(epcInput, {
+        target: { value: "300833B2DDD9014000000001" },
+      });
       fireEvent.click(screen.getByRole("button", { name: "Cancelar" }));
     });
 
@@ -127,22 +131,26 @@ describe("TagAddModal component", () => {
     renderModalWithClose(onClose);
 
     fireEvent.change(screen.getByLabelText("TID"), {
-      target: { value: "TID-001" },
+      target: { value: "E20034120130000000000001" },
     });
     fireEvent.change(screen.getByLabelText("EPC"), {
-      target: { value: "EPC-001" },
+      target: { value: "300833B2DDD9014000000001" },
     });
 
-    await fireEvent.submit(
-      screen.getByRole("button", { name: "Confirmar" }).closest("form")!,
-    );
+    const form = screen
+      .getByRole("button", { name: "Confirmar" })
+      .closest("form");
+    expect(form).not.toBeNull();
+    if (form) {
+      await fireEvent.submit(form);
+    }
 
     await createTagMock.mock.results[0]?.value;
 
     expect(createTagMock).toHaveBeenCalledTimes(1);
     expect(createTagMock.mock.calls[0]?.[0]).toEqual({
-      tid: "TID-001",
-      epc: "EPC-001",
+      tid: "E20034120130000000000001",
+      epc: "300833B2DDD9014000000001",
     });
     expect(toastSuccessSpy).toHaveBeenCalledWith(
       "Etiqueta adicionada com sucesso.",
@@ -157,15 +165,19 @@ describe("TagAddModal component", () => {
     renderModal();
 
     fireEvent.change(screen.getByLabelText("TID"), {
-      target: { value: "TID-001" },
+      target: { value: "E20034120130000000000001" },
     });
     fireEvent.change(screen.getByLabelText("EPC"), {
-      target: { value: "EPC-001" },
+      target: { value: "300833B2DDD9014000000001" },
     });
 
-    await fireEvent.submit(
-      screen.getByRole("button", { name: "Confirmar" }).closest("form")!,
-    );
+    const form = screen
+      .getByRole("button", { name: "Confirmar" })
+      .closest("form");
+    expect(form).not.toBeNull();
+    if (form) {
+      await fireEvent.submit(form);
+    }
 
     await createTagMock.mock.results[0]?.value.catch(() => undefined);
 

--- a/src/features/tags/components/TagAddModal.tsx
+++ b/src/features/tags/components/TagAddModal.tsx
@@ -1,5 +1,4 @@
-import { MinusIcon, PlusIcon } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
@@ -11,74 +10,39 @@ interface TagAddModalProps {
   onClose: () => void;
 }
 
-type TagEntry = { id: string; value: string };
-
-const newEntry = (): TagEntry => ({ id: crypto.randomUUID(), value: "" });
-
 export function TagAddModal({ isOpen, onClose }: TagAddModalProps) {
-  const [tags, setTags] = useState<TagEntry[]>([newEntry()]);
+  const [tid, setTid] = useState("");
+  const [epc, setEpc] = useState("");
 
   const createTagMutation = useCreateTag();
   const isSubmitting = createTagMutation.isPending;
 
-  const handleChange = (id: string, value: string) => {
-    setTags((prev) =>
-      prev.map((tag) => (tag.id === id ? { ...tag, value } : tag)),
-    );
-  };
-
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-
-  const handleAddInput = () => {
-    setTags((prev) => [...prev, newEntry()]);
-    if (scrollContainerRef.current) {
-      scrollContainerRef.current.style.pointerEvents = "none";
-    }
-    setTimeout(() => {
-      if (scrollContainerRef.current) {
-        scrollContainerRef.current.scrollTop =
-          scrollContainerRef.current.scrollHeight;
-        scrollContainerRef.current.style.pointerEvents = "";
-      }
-    }, 0);
-  };
-
-  const handleRemoveInput = (id: string) => {
-    setTags((prev) => prev.filter((tag) => tag.id !== id));
-  };
-
   const handleCancel = () => {
-    setTags([newEntry()]);
+    setTid("");
+    setEpc("");
     onClose();
   };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    const filled = tags.map((t) => t.value.trim()).filter(Boolean);
+    const cleanTid = tid.trim();
+    const cleanEpc = epc.trim();
 
-    if (filled.length === 0) {
-      toast.error("Preencha pelo menos um ID de etiqueta.");
+    if (!cleanTid || !cleanEpc) {
+      toast.error("Preencha o TID e o EPC da etiqueta.");
       return;
     }
 
     try {
-      for (const tagId of filled) {
-        await createTagMutation.mutateAsync({ tagId });
-      }
-
-      const count = filled.length;
-      toast.success(
-        count === 1
-          ? "Etiqueta adicionada com sucesso."
-          : `${count} etiquetas adicionadas com sucesso.`,
-      );
-
-      setTags([newEntry()]);
+      await createTagMutation.mutateAsync({ tid: cleanTid, epc: cleanEpc });
+      toast.success("Etiqueta adicionada com sucesso.");
+      setTid("");
+      setEpc("");
       onClose();
     } catch {
       toast.error(
-        "Erro ao adicionar etiqueta(s). Verifique os IDs e tente novamente.",
+        "Erro ao adicionar etiqueta. Verifique os campos e tente novamente.",
       );
     }
   };
@@ -87,44 +51,27 @@ export function TagAddModal({ isOpen, onClose }: TagAddModalProps) {
     <Modal
       isOpen={isOpen}
       onClose={handleCancel}
-      title="Adicionar etiquetas RFID"
+      title="Adicionar etiqueta RFID"
     >
       <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-        <div
-          ref={scrollContainerRef}
-          className="flex max-h-[50dvh] flex-col gap-4 overflow-y-auto"
-        >
-          <div className="mx-auto flex w-full max-w-xs flex-col gap-4">
-            {tags.map((tag, index) => {
-              const isLast = index === tags.length - 1;
-              return (
-                <div key={tag.id} className="flex items-end gap-2">
-                  <Input
-                    label="ID"
-                    placeholder="123456789"
-                    value={tag.value}
-                    width="100%"
-                    onChange={(e) => handleChange(tag.id, e.target.value)}
-                  />
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    icon
-                    className="flex h-10 w-10 items-center justify-center"
-                    onClick={
-                      isLast ? handleAddInput : () => handleRemoveInput(tag.id)
-                    }
-                    aria-label={isLast ? "Adicionar campo" : "Remover campo"}
-                  >
-                    {isLast ? <PlusIcon size={16} /> : <MinusIcon size={16} />}
-                  </Button>
-                </div>
-              );
-            })}
-          </div>
+        <div className="mx-auto flex w-full max-w-xs flex-col gap-4">
+          <Input
+            label="TID"
+            placeholder="Ex: E200341201300000..."
+            value={tid}
+            width="100%"
+            onChange={(e) => setTid(e.target.value)}
+          />
+          <Input
+            label="EPC"
+            placeholder="Ex: 300833B2DDD90140..."
+            value={epc}
+            width="100%"
+            onChange={(e) => setEpc(e.target.value)}
+          />
         </div>
 
-        <div className="flex justify-end gap-2 pt-2">
+        <div className="flex justify-end gap-2 pt-4">
           <Button type="button" variant="borderless" onClick={handleCancel}>
             Cancelar
           </Button>

--- a/src/features/tags/components/TagDeactivateModal.spec.tsx
+++ b/src/features/tags/components/TagDeactivateModal.spec.tsx
@@ -30,8 +30,8 @@ const { TagDeactivateModal } = await import("./TagDeactivateModal");
 
 const mockTag: TagListItemDto = {
   tagId: "tag-001",
-  tid: "TID-001",
-  epc: "EPC-001",
+  tid: "E20034120130000000000001",
+  epc: "300833B2DDD9014000000001",
   userName: "John Doe",
   plate: "ABC-1234",
   status: "IN_USE",

--- a/src/features/tags/components/TagDeactivateModal.spec.tsx
+++ b/src/features/tags/components/TagDeactivateModal.spec.tsx
@@ -29,7 +29,9 @@ useDeactivateTagSpy.mockImplementation(
 const { TagDeactivateModal } = await import("./TagDeactivateModal");
 
 const mockTag: TagListItemDto = {
-  id: "tag-001",
+  tagId: "tag-001",
+  tid: "TID-001",
+  epc: "EPC-001",
   userName: "John Doe",
   plate: "ABC-1234",
   status: "IN_USE",

--- a/src/features/tags/components/TagDeactivateModal.tsx
+++ b/src/features/tags/components/TagDeactivateModal.tsx
@@ -21,7 +21,7 @@ export function TagDeactivateModal({
   const handleConfirm = () => {
     if (!tag) return;
 
-    deactivateMutation.mutate(tag.id, {
+    deactivateMutation.mutate(tag.tagId, {
       onSuccess: () => {
         toast.success("Etiqueta desativada com sucesso.");
         onClose();

--- a/src/features/tags/components/TagDetailsModal.spec.tsx
+++ b/src/features/tags/components/TagDetailsModal.spec.tsx
@@ -4,7 +4,9 @@ import type { TagListItemDto } from "../dtos";
 import { TagDetailsModal } from "./TagDetailsModal";
 
 const mockTag: TagListItemDto = {
-  id: "tag-001",
+  tagId: "tag-001",
+  tid: "TID-001",
+  epc: "EPC-001",
   userName: "John Doe",
   plate: "ABC-1234",
   status: "AVAILABLE",
@@ -15,12 +17,13 @@ describe("TagDetailsModal component", () => {
 
   it("should not render content when tag is null", () => {
     render(<TagDetailsModal isOpen={true} onClose={mock()} tag={null} />);
-    expect(screen.queryByText("tag-001")).toBeNull();
+    expect(screen.queryByText("TID-001")).toBeNull();
   });
 
-  it("should render the tag id", () => {
+  it("should render the tag TID and EPC", () => {
     render(<TagDetailsModal isOpen={true} onClose={mock()} tag={mockTag} />);
-    expect(screen.getByText("tag-001")).toBeDefined();
+    expect(screen.getByText("TID-001")).toBeDefined();
+    expect(screen.getByText("EPC-001")).toBeDefined();
   });
 
   it("should render the tag owner name", () => {
@@ -58,6 +61,6 @@ describe("TagDetailsModal component", () => {
 
   it("should not render content when isOpen is false", () => {
     render(<TagDetailsModal isOpen={false} onClose={mock()} tag={mockTag} />);
-    expect(screen.queryByText("tag-001")).toBeNull();
+    expect(screen.queryByText("TID-001")).toBeNull();
   });
 });

--- a/src/features/tags/components/TagDetailsModal.spec.tsx
+++ b/src/features/tags/components/TagDetailsModal.spec.tsx
@@ -5,8 +5,8 @@ import { TagDetailsModal } from "./TagDetailsModal";
 
 const mockTag: TagListItemDto = {
   tagId: "tag-001",
-  tid: "TID-001",
-  epc: "EPC-001",
+  tid: "E20034120130000000000001",
+  epc: "300833B2DDD9014000000001",
   userName: "John Doe",
   plate: "ABC-1234",
   status: "AVAILABLE",
@@ -17,13 +17,13 @@ describe("TagDetailsModal component", () => {
 
   it("should not render content when tag is null", () => {
     render(<TagDetailsModal isOpen={true} onClose={mock()} tag={null} />);
-    expect(screen.queryByText("TID-001")).toBeNull();
+    expect(screen.queryByText("E20034120130000000000001")).toBeNull();
   });
 
   it("should render the tag TID and EPC", () => {
     render(<TagDetailsModal isOpen={true} onClose={mock()} tag={mockTag} />);
-    expect(screen.getByText("TID-001")).toBeDefined();
-    expect(screen.getByText("EPC-001")).toBeDefined();
+    expect(screen.getByText("E20034120130000000000001")).toBeDefined();
+    expect(screen.getByText("300833B2DDD9014000000001")).toBeDefined();
   });
 
   it("should render the tag owner name", () => {
@@ -61,6 +61,6 @@ describe("TagDetailsModal component", () => {
 
   it("should not render content when isOpen is false", () => {
     render(<TagDetailsModal isOpen={false} onClose={mock()} tag={mockTag} />);
-    expect(screen.queryByText("TID-001")).toBeNull();
+    expect(screen.queryByText("E20034120130000000000001")).toBeNull();
   });
 });

--- a/src/features/tags/components/TagDetailsModal.tsx
+++ b/src/features/tags/components/TagDetailsModal.tsx
@@ -20,8 +20,12 @@ export function TagDetailsModal({
         <div className="space-y-4">
           <div className="grid gap-4 sm:grid-cols-2">
             <div>
-              <p className="text-gray text-xs uppercase tracking-wide">ID</p>
-              <p className="break-all font-medium text-dark-gray">{tag.id}</p>
+              <p className="text-gray text-xs uppercase tracking-wide">TID</p>
+              <p className="break-all font-medium text-dark-gray">{tag.tid}</p>
+            </div>
+            <div>
+              <p className="text-gray text-xs uppercase tracking-wide">EPC</p>
+              <p className="break-all font-medium text-dark-gray">{tag.epc}</p>
             </div>
             <div>
               <p className="text-gray text-xs uppercase tracking-wide">

--- a/src/features/tags/dtos/createTagDto.ts
+++ b/src/features/tags/dtos/createTagDto.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
 export const createTagSchema = z.object({
-  tagId: z.string().min(1),
+  tid: z.string().min(1),
+  epc: z.string().min(1),
 });
 
 export type CreateTagDto = z.infer<typeof createTagSchema>;

--- a/src/features/tags/dtos/createTagDto.ts
+++ b/src/features/tags/dtos/createTagDto.ts
@@ -1,8 +1,14 @@
 import { z } from "zod";
 
 export const createTagSchema = z.object({
-  tid: z.string().min(1),
-  epc: z.string().min(1),
+  tid: z
+    .string()
+    .min(1)
+    .regex(/^[0-9a-fA-F]+$/, "TID deve conter apenas caracteres hexadecimais"),
+  epc: z
+    .string()
+    .min(1)
+    .regex(/^[0-9a-fA-F]+$/, "EPC deve conter apenas caracteres hexadecimais"),
 });
 
 export type CreateTagDto = z.infer<typeof createTagSchema>;

--- a/src/features/tags/dtos/tagDto.ts
+++ b/src/features/tags/dtos/tagDto.ts
@@ -4,6 +4,8 @@ export const tagSchema = z.object({
   tagId: z.string(),
   status: z.string(),
   vehicleId: z.string().uuid().nullable().optional(),
+  tid: z.string(),
+  epc: z.string(),
 });
 
 export type TagDto = z.infer<typeof tagSchema>;

--- a/src/features/tags/dtos/tagListDto.ts
+++ b/src/features/tags/dtos/tagListDto.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 import { tagStatusSchema } from "./tagStatusDto";
 
 export const tagListItemSchema = z.object({
-  id: z.string(),
+  tagId: z.string(),
+  tid: z.string(),
+  epc: z.string(),
   userName: z.string().nullable(),
   plate: z.string().nullable(),
   status: tagStatusSchema,

--- a/src/features/tags/hooks/useTagsModalState.spec.ts
+++ b/src/features/tags/hooks/useTagsModalState.spec.ts
@@ -5,8 +5,8 @@ import { useTagsModalState } from "./useTagsModalState";
 
 const mockTag: TagListItemDto = {
   tagId: "tag-001",
-  tid: "TID-001",
-  epc: "EPC-001",
+  tid: "E20034120130000000000001",
+  epc: "300833B2DDD9014000000001",
   userName: "John Doe",
   plate: "ABC-1234",
   status: "IN_USE",

--- a/src/features/tags/hooks/useTagsModalState.spec.ts
+++ b/src/features/tags/hooks/useTagsModalState.spec.ts
@@ -4,7 +4,9 @@ import type { TagListItemDto } from "../dtos";
 import { useTagsModalState } from "./useTagsModalState";
 
 const mockTag: TagListItemDto = {
-  id: "tag-001",
+  tagId: "tag-001",
+  tid: "TID-001",
+  epc: "EPC-001",
   userName: "John Doe",
   plate: "ABC-1234",
   status: "IN_USE",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import ky from "ky";
 import { env } from "@/config/env";
-import { TOKEN_KEY } from "@/features/auth/AuthService";
+
+export const TOKEN_KEY = "rfid-auth-token";
 
 export type ApiClient = typeof ky;
 

--- a/src/routes/admin/tags.tsx
+++ b/src/routes/admin/tags.tsx
@@ -33,8 +33,14 @@ export function Tags() {
   const columns = useMemo<TableColumn<TagListItemDto>[]>(
     () => [
       {
-        key: "id",
-        title: "ID",
+        key: "tid",
+        title: "TID",
+        className: "w-48 whitespace-nowrap",
+        sortable: true,
+      },
+      {
+        key: "epc",
+        title: "EPC",
         className: "w-48 whitespace-nowrap",
         sortable: true,
       },
@@ -100,7 +106,7 @@ export function Tags() {
         actions={actions}
         loading={isLoading}
         paginationPageSize={10}
-        searchPlaceholder="Pesquisar por ID, proprietário ou placa"
+        searchPlaceholder="Pesquisar por TID, EPC, proprietário ou placa"
         emptyMessage="Nenhuma etiqueta cadastrada ainda."
         searchNotFoundMessage="Nenhuma etiqueta encontrada para esta busca."
         onRowClick={(tag) => open("details", tag)}


### PR DESCRIPTION
- Atualizamos os modais de criação, detalhes e desativação para suportar TID e EPC.
- Substituimos a coluna ID pelas colunas TID e EPC na rota de tags do admin.
- Atualizamos os schemas do Zod e as definições de tipo para corresponderem aos modelos do backend.
- Resolvemos a dependência circular entre api.ts e AuthService.ts para corrigir a execução dos testes.
- Adaptamos os testes unitários do frontend para a nova estrutura de tags.
<img width="762" height="260" alt="tabelaTIDEPC-ages" src="https://github.com/user-attachments/assets/69129677-6c21-4634-ab77-26c96644d038" />